### PR TITLE
Screenshot to clipboard accessible via /image tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "@raycast/api": "^1.55.2",
         "@raycast/utils": "^1.9.0",
+        "file-type": "^19.0.0",
         "langchain": "^0.0.183",
         "mime-types": "^2.1.35",
         "node-fetch": "^3.3.2",
@@ -387,6 +388,11 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.5.1.tgz",
       "integrity": "sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==",
       "dev": true
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1836,6 +1842,22 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.0.0.tgz",
+      "integrity": "sha512-s7cxa7/leUWLiXO78DVVfBVse+milos9FitauDLG1pI7lNaJ2+5lzPnr2N24ym+84HVwJL6hVuGfgVE+ALvU8Q==",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0",
+        "token-types": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -1884,9 +1906,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -2149,9 +2171,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "optional": true,
-      "peer": true
+      ]
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -2200,8 +2220,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -3446,6 +3465,18 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/peek-stream": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
@@ -3694,6 +3725,34 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -3797,9 +3856,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "optional": true,
-      "peer": true
+      ]
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -3949,8 +4006,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -3991,6 +4046,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -4174,6 +4245,22 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/token-types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -4273,9 +4360,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -157,10 +157,10 @@
       "mode": "view",
       "arguments": [
         {
-         "name": "language",
-         "placeholder": "To Language",
-         "type": "text",
-         "required": true
+          "name": "language",
+          "placeholder": "To Language",
+          "type": "text",
+          "required": true
         }
       ]
     },
@@ -226,6 +226,7 @@
   "dependencies": {
     "@raycast/api": "^1.55.2",
     "@raycast/utils": "^1.9.0",
+    "file-type": "^19.0.0",
     "langchain": "^0.0.183",
     "mime-types": "^2.1.35",
     "node-fetch": "^3.3.2",

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -8,7 +8,7 @@ import {
 } from "./types";
 import { getSelectedFinderItems, Clipboard, LocalStorage } from "@raycast/api";
 import fs from "fs";
-import mime from "mime-types";
+import { fileTypeFromBuffer } from "file-type/core";
 import fetch from "node-fetch";
 import { OllamaApiShow, OllamaApiShowParseModelfile, OllamaApiTags } from "./ollama";
 import {
@@ -61,19 +61,18 @@ export async function GetImageFromUrl(url: string): Promise<RaycastImage | undef
  * Get Image from disk.
  * @param {string} file
  */
-export async function GetImageFromFile(file: string) {
+export async function GetImageFromFile(file: string): Promise<RaycastImage> {
   if (!file.match(/(file:)?([/|.|\w|\s|-])/g)) throw new Error("Only PNG and JPG are supported");
 
   file = file.replace("file://", "");
-  const contentType = mime.lookup(file);
-  if (contentType === "image/jpeg" || contentType === "image/png") {
-    const blob = fs.readFileSync(file);
-    const base64 = Buffer.from(blob).toString("base64");
+  const buffer = fs.readFileSync(decodeURI(file));
+  const { mime } = (await fileTypeFromBuffer(buffer)) || {};
+  if (mime === "image/jpeg" || mime === "image/png") {
     return {
       path: file,
       html: `<img src="${file}" alt="image" height="180" width="auto">`,
-      base64: base64,
-    } as RaycastImage;
+      base64: buffer.toString("base64"),
+    };
   } else {
     throw new Error("Only PNG and JPG are supported");
   }

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -66,8 +66,8 @@ export async function GetImageFromFile(file: string): Promise<RaycastImage> {
 
   file = file.replace("file://", "");
   const buffer = fs.readFileSync(decodeURI(file));
-  const { mime } = (await fileTypeFromBuffer(buffer)) || {};
-  if (mime === "image/jpeg" || mime === "image/png") {
+  const fileType = await fileTypeFromBuffer(buffer);
+  if (fileType && (fileType.mime === "image/jpeg" || fileType.mime === "image/png")) {
     return {
       path: file,
       html: `<img src="${file}" alt="image" height="180" width="auto">`,


### PR DESCRIPTION
# Purpose

The functionality I wanted to add was being able to use the `/image` tag to access screenshots taken with the CMD + OPTION + SHIFT + 4 combination (allows you to select an area to screenshot). The screenshots taken this way are stored in a temporary file such that their `Clipboard.ReadContent` entries return as follows.

```js
{
    file: 'file:///var/folders/g1/rcmxcq7915g5l93035hf1g6c0000gn/T/Image%20(212x148)',
    text: 'Image (212x148)',
    html: '<img src="file:///var/folders/g1/rcmxcq7915g5l93035hf1g6c0000gn/T/Image%20(212x148)" alt="Image (212x148)" />'
}
```

## Problem

Since a file property is present in this response, I have updated the `GetImageFromFile` function to handle URL's of this form. The two primary issue that this PR addresses is that the this file URL has an encoded space character, as well as no file extension.

## Solution

- To fix the encoded space, the file prop of the response is passed to `decodeURI` before being passed to `readFileSync`
- To fix the lack of extension, a new library, [`file-type`](https://www.npmjs.com/package/file-type), is included to parse the images MIME type from the binary structure of the file as opposed to the extension. This was not possible with the old library