### PR TITLE
Fix typos and grammar in the Custom Command tooltip

### DIFF
--- a/src/ollama-custom-create.tsx
+++ b/src/ollama-custom-create.tsx
@@ -50,9 +50,9 @@ export default function Command(): JSX.Element {
 - High: 1.5
 - Maximum: 2`;
   const InfoPrompt = `Prompt Template, you can download public prompt form prompts.ray.so.
-Following tag are supported:
+The following tags are supported:
 - {selection}: Add selected text or clipboard to the prompt.
-- {broswer-tab}: Add current browser tab text to the prompt. Use {broser-tab format="markdown|html|text"} if you need a differente format from markdown. Raycast Browser Extention is required.
+- {browser-tab}: Add current browser tab text to the prompt. Use {browser-tab format="markdown|html|text"} if you need a different format from Markdown. The Raycast Browser Extension is required.
 - {image}: Add image on clipboard to the prompt. A model with vision capability is required.`;
 
   const ActionView = (


### PR DESCRIPTION
Fixes a few typos I spotted in the Custom Command tooltip.