### PR TITLE
Improve processing streaming response from Ollama.

### DIFF
--- a/src/lib/ollama/ollama.ts
+++ b/src/lib/ollama/ollama.ts
@@ -25,7 +25,7 @@ export class Ollama {
    * @param server - Ollama Server Route, default value: { url: "http://127.0.0.1:11434" }.
    */
   constructor(server = { url: "http://127.0.0.1:11434" } as Types.OllamaServer) {
-    this._signal = AbortSignal.timeout(180);
+    this._signal = AbortSignal.timeout(1800);
     this._server = server.url;
     if (server.auth && server.auth.mode === Enum.OllamaServerAuthorizationMethod.BASIC)
       this._headers = {
@@ -596,12 +596,14 @@ export class Ollama {
   }
 
   /**
-   * Perform text generation with the selected model.
-   * @param body - Ollama Generate Body Request.
-   * @returns Response from the Ollama API with an EventEmitter with two event: `data` where all generated text is passed on `string` format and `done` when inference is finished returning a `OllamaApiGenerateResponse` object contains all metadata of inference.
+   * Handle streaming API response.
+   * @param route - Route path of the API.
+   * @param body - Request Body.
+   * @param contentExtractor - Extract content from response.
+   * @returns Response from the Ollama API with an EventEmitter with two event: `data` where all generated text is passed on `string` format and `done` when inference is finished returning an object contains all metadata of inference.
+   * @private
    */
-  async OllamaApiGenerate(body: Types.OllamaApiGenerateRequestBody): Promise<EventEmitter> {
-    const route = this._RouteApiGenerate;
+  private async _OllamaApiStream<T extends {model: string}>(route: string, body: T, contentExtractor: (json: Types.OllamaApiChatResponse | Types.OllamaErrorResponse | undefined) => string | undefined): Promise<EventEmitter> {
     const url = `${this._server}${route}`;
     const req: RequestInit = {
       method: "POST",
@@ -611,6 +613,7 @@ export class Ollama {
     let emitter: EventEmitter | undefined;
 
     while (emitter === undefined) {
+      let part = '';
       emitter = await fetch(url, req)
         .then(async (response) => {
           if (!response.ok) {
@@ -626,25 +629,37 @@ export class Ollama {
 
           const e = new EventEmitter();
 
+          const emitContent = (json: Types.OllamaApiChatResponse | Types.OllamaErrorResponse | undefined) => {
+            if (json)
+              if ("done" in json) {
+                if (json.done) {
+                  e.emit("done", json);
+                } else {
+                  const content = contentExtractor(json);
+                  if (content) e.emit("data", content);
+                }
+              } else if ("error" in json && json.error) {
+                e.emit("error", json);
+              }
+          }
+
           body?.on("data", (chunk) => {
             if (chunk !== undefined) {
-              let json: Types.OllamaApiGenerateResponse | Types.OllamaErrorResponse | undefined;
               const buffer = Buffer.from(chunk);
-              try {
-                json = JSON.parse(buffer.toString());
-              } catch (err) {
-                console.error(err);
+              let jsonStr = buffer.toString();
+              if (part !== '') {
+                jsonStr = part + jsonStr;
               }
-              if (json)
-                if ("done" in json) {
-                  if (json.done) {
-                    e.emit("done", json);
-                  } else {
-                    if ("response" in json && json.response) e.emit("data", json.response);
-                  }
-                } else if ("error" in json && json.error) {
-                  e.emit("error", json);
+              for (const j of jsonStr.split('\n').filter(p => p !== '')) {
+                try {
+                  const json = JSON.parse(j);
+                  emitContent(json);
+                  part = '';
+                } catch (err) {
+                  console.error(err);
+                  part += j;
                 }
+              }
             }
           });
 
@@ -660,67 +675,25 @@ export class Ollama {
   }
 
   /**
+   * Perform text generation with the selected model.
+   * @param body - Ollama Generate Body Request.
+   * @returns Response from the Ollama API with an EventEmitter with two event: `data` where all generated text is passed on `string` format and `done` when inference is finished returning a `OllamaApiGenerateResponse` object contains all metadata of inference.
+   */
+  async OllamaApiGenerate(body: Types.OllamaApiGenerateRequestBody): Promise<EventEmitter> {
+    return await this._OllamaApiStream(this._RouteApiGenerate, body, (json) => {
+      if (json && "response" in json && json.response) return json.response as string;
+    });
+  }
+
+  /**
    * Perform conversation with the selected model.
    * @param body - Ollama Chat Body Request.
    * @returns Response from the Ollama API with an EventEmitter with two event: `data` where all generated text is passed on `string` format and `done` when inference is finished returning a `OllamaApiChatResponse` object contains all metadata of inference.
    */
   async OllamaApiChat(body: Types.OllamaApiChatRequestBody): Promise<EventEmitter> {
-    const route = this._RouteApiChat;
-    const url = `${this._server}${route}`;
-    const req: RequestInit = {
-      method: "POST",
-      headers: this._headers,
-      body: JSON.stringify(body),
-    };
-    let emitter: EventEmitter | undefined;
-
-    while (emitter === undefined) {
-      emitter = await fetch(url, req)
-        .then(async (response) => {
-          if (!response.ok) {
-            const message = (await response.json()) as Types.OllamaErrorResponse;
-            this._ErrorHandlerOllamaServer(route, response.status, message, req, body.model);
-          }
-          return response.body;
-        })
-        .then((body) => {
-          if (body === undefined) {
-            return undefined;
-          }
-
-          const e = new EventEmitter();
-
-          body?.on("data", (chunk) => {
-            if (chunk !== undefined) {
-              let json: Types.OllamaApiChatResponse | Types.OllamaErrorResponse | undefined;
-              const buffer = Buffer.from(chunk);
-              try {
-                json = JSON.parse(buffer.toString());
-              } catch (err) {
-                console.error(err);
-              }
-              if (json)
-                if ("done" in json) {
-                  if (json.done) {
-                    e.emit("done", json);
-                  } else {
-                    json.message && e.emit("data", json.message.content);
-                  }
-                } else if ("error" in json && json.error) {
-                  e.emit("error", json);
-                }
-            }
-          });
-
-          return e;
-        })
-        .catch((err: FetchError | Error) => {
-          this._ErrorLogger(err);
-          if (err instanceof FetchError && err.type === "ECONNREFUSED") throw Errors.OllamaNotInstalledOrRunning;
-          throw err;
-        });
-    }
-    return emitter;
+    return await this._OllamaApiStream(this._RouteApiChat, body, (json) => {
+      if (json && "message" in json && json.message) return json.message.content;
+    });
   }
 
   /**


### PR DESCRIPTION
In high latency network (I hosted an `Ollama` instance on my `Mac mini` and expose it to the internet by `Cloudflare tunnel`), the response may contain multiple lines of `JSON`, or even partial `JSON`:
```json
{"model":"qwen2.5-coder:3b","created_at":"2025-01-27T16:49:20.788592Z","message":{"role":"assistant","content":"Hello"},"done":false}
{"model":"qwen2.5-coder:3b","created_at":"2025-01-27T16:49:20.811022Z","message":{"role":"assistant","content":"!"},"done":false}
{"model":"qwen2.5-coder:3b","created_at":"2025-01-27T16:49:20.832937Z","message":{"role":"assistant","content":" How"},"done":false}
{"model":"qwen2.5-coder:3b","created_at":"2025-01-27T16:49:20.854766Z","message":{"role":"assistant","content":" can"},"done":false}
{"model":"qwen2.5-coder:3b","created_at":"2025-01-27T16:49:20
```

<img width="1486" alt="Screenshot 2025-01-28 at 12 38 23 PM" src="https://github.com/user-attachments/assets/e22dc637-e16d-4bae-8e45-bc33313e4e19" />

This PR added handling for such situation.